### PR TITLE
remove the default value for datetime field.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Here's a sample schema file:
       string    :body,        optional: false
       integer32 :length
       boolean   :published,   default: false
-      datetime  :publishedAt, default: false
+      datetime  :publishedAt
       string    :title,       optional: false
 
       belongs_to :author


### PR DESCRIPTION
The datetime can't not have the default value as false.
to fix the error in my app: Sequel::DatabaseError: PG::InvalidDatetimeFormat: ERROR:  invalid input syntax for type timestamp: "NO"
