### PR TITLE
Added test for entities that end  's' and has_one

### DIFF
--- a/test/entity_test.rb
+++ b/test/entity_test.rb
@@ -91,6 +91,13 @@ module XCDM
                       "Author", inverseName: "article", inverseEntity: "Author" }], e.relationships
     end
 
+    def test_has_one_should_not_plural
+      e.has_one 'address'
+      assert_equal [{ optional: "YES", deletionRule: "Nullify", syncable: "YES",
+                      name: "address", minCount: "1", maxCount: "1", destinationEntity:
+                      "Address", inverseName: "article", inverseEntity: "Address" }], e.relationships
+    end
+
     def test_belongs_to
       e.belongs_to 'author'
       assert_equal [{ optional: "YES", deletionRule: "Nullify", syncable: "YES",


### PR DESCRIPTION
The reason for this test is that release 0.0.8 has a bug where if you have an
entity with the name 'Address' and another entity 'has_one :address',
the relationship is not properly handled.

In other words, if you run this test for verson 0.0.8, it fails. On
master, it succeeds. So this test is simply to prevent regression.

I believe the fix to this was updating the version of ActiveSupport.