### PR TITLE
Update regexp for compatability with Xcode 10+

### DIFF
--- a/lib/ruby-xcdm.rb
+++ b/lib/ruby-xcdm.rb
@@ -27,7 +27,7 @@ if defined?(Motion::Project::Config)
       task :build => :clean do
         App.config.xcdm.name ||= App.config.name
         Dir.chdir App.config.project_dir
-        if `xcodebuild -version` =~ /Xcode (\d.\d+)/
+        if `xcodebuild -version` =~ /Xcode (\d+.\d+)/
           xcode_version = $1
         else
           raise "could not determine xcode version"


### PR DESCRIPTION
I'm not quite sure why this is done at all, because `xcode_version` does not seem to be used, but this is necessary for compatibility with Xcode 10.