### PR TITLE
Well.. its double version digits now ...

### DIFF
--- a/lib/ruby-xcdm.rb
+++ b/lib/ruby-xcdm.rb
@@ -27,7 +27,7 @@ if defined?(Motion::Project::Config)
       task :build => :clean do
         App.config.xcdm.name ||= App.config.name
         Dir.chdir App.config.project_dir
-        if `xcodebuild -version` =~ /Xcode (\d.\d+)/
+        if `xcodebuild -version` =~ /Xcode (\d+.\d+)/
           xcode_version = $1
         else
           raise "could not determine xcode version"


### PR DESCRIPTION
Xcode 10.0 is out, and thus the regular expression to match the version number output of xcodebuild -version fails. Its a trivial patch.